### PR TITLE
Add update link status functionality

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,8 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
- 
- 
+
+
  */
+
+ @import "custom";

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,0 +1,8 @@
+a:visited {
+  color: blue;
+}
+
+a.read {
+  text-decoration: line-through;
+  color: gray;
+}

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -17,9 +17,15 @@ class LinksController < ApplicationController
     end
   end
 
+  def update
+    @link = Link.find(params[:id])
+    @link.update_attributes(link_params)
+    redirect_to root_path
+  end
+
   private
 
     def link_params
-      params.require(:link).permit(:url, :title)
+      params.require(:link).permit(:url, :title, :read)
     end
 end

--- a/app/views/links/index.html.erb
+++ b/app/views/links/index.html.erb
@@ -20,9 +20,9 @@
   <%= link.title %> -
   <%= link_to link.url, "#{link.url}" %> -
   <% if link.read %>
-    <%= link_to "Mark as Unread", link_path(link, link: {read: false}), method: :patch %>
+    <%= link_to "Mark as Unread", link_path(link, link: {read: false}), method: :patch, class: :read %>
   <% else %>
-    <%= link_to "Mark as Read", link_path(link, link: {read: true}), method: :patch %>
+    <%= link_to "Mark as Read", link_path(link, link: {read: true}), method: :patch, class: :unread %>
   <% end %>
   <br/>
 <% end %>

--- a/app/views/links/index.html.erb
+++ b/app/views/links/index.html.erb
@@ -18,6 +18,11 @@
 
 <% @links.each do |link| %>
   <%= link.title %> -
-  <%= link_to link.url, "#{link.url}" %>
+  <%= link_to link.url, "#{link.url}" %> -
+  <% if link.read %>
+    <%= link_to "Mark as Unread", link_path(link, link: {read: false}), method: :patch %>
+  <% else %>
+    <%= link_to "Mark as Read", link_path(link, link: {read: true}), method: :patch %>
+  <% end %>
   <br/>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root "links#index"
 
   resources :users, only: [:new, :create]
-  resources :links, only: [:index, :create]
+  resources :links, only: [:index, :create, :update]
 
   get "/enter", to: "sessions#enter"
   get "/login", to: "sessions#new"

--- a/test/integration/upadate_link_status_test.rb
+++ b/test/integration/upadate_link_status_test.rb
@@ -13,4 +13,17 @@ class UserUpdatesLinkStatusTest < ActionDispatch::IntegrationTest
 
     assert page.has_content?("Mark as Unread")
   end
+
+  test "User clicks on Mark as Unread link and observes change" do
+    user = User.create(email: "me@email.com", password: "password")
+    user.links << Link.create(title: "MyPlace", url: "https://www.myplace.com", read: true)
+    login(user)
+
+    assert page.has_content?("Mark as Unread")
+    refute page.has_content?("Mark as Read")
+
+    click_on("Mark as Unread")
+
+    assert page.has_content?("Mark as Read")
+  end
 end

--- a/test/integration/upadate_link_status_test.rb
+++ b/test/integration/upadate_link_status_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class UserUpdatesLinkStatusTest < ActionDispatch::IntegrationTest
+  test "User clicks on Mark as Read link and observes change" do
+    user = User.create(email: "me@email.com", password: "password")
+    user.links << Link.create(title: "MyPlace", url: "https://www.myplace.com")
+    login(user)
+
+    assert page.has_content?("Mark as Read")
+    refute page.has_content?("Mark as Unread")
+
+    click_on("Mark as Read")
+
+    assert page.has_content?("Mark as Unread")
+  end
+end


### PR DESCRIPTION
Add "Mark as Read" or "Mark as Unread" links to each link depending on the "read" status of the link.
"Mark as Unread" links are rendered as grey with a strikethrough.

Clicking on one of the status change links, changes the "read" status of the link and then renders with the opposite link status.
